### PR TITLE
Adding USB error handling on read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 !**/Build/CMAKE_README.txt
 
 .DS_Store
+
+.idea

--- a/Source/USBThread.h
+++ b/Source/USBThread.h
@@ -41,6 +41,7 @@ namespace RhythmNode
 		void startAcquisition(int nBytes);
 		void stopAcquisition();
 		long usbRead(unsigned char*&);
+        bool hasErrored();
 	private:
 		Rhd2000EvalBoardUsb3* const m_board;
 		HeapBlock<unsigned char> m_buffers[2];
@@ -49,6 +50,7 @@ namespace RhythmNode
 		unsigned short m_readBuffer{ 0 };
 		bool m_canRead{ false };
 		CriticalSection m_lock;
+        bool has_errored = false;
 	};
 
 }


### PR DESCRIPTION
When performing the RHD Controller USB disconnection test (i.e. disconnecting the USB between the RHD Controller and the PC), UI hangs indefinitely, and becomes unresponsive to stopping acquisition by clicking "Play" or "Record". This should fix that hanging by respecting the negative return code in the USB read.

@admunkucsd FYI